### PR TITLE
Support old behavior of addObjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,9 @@ Add muti-player networking with [FirebaseSync]
 var firebaseRootURL = "https://your-firebase-root.firebaseio.com/";
 var appId = "Your-App-Name";
 firebaseSync = new FirebaseSync( firebaseRootURL, appId );
-firebaseSync.connect( onConnected );
-...
-// after connected (e.g. in onConnected callback)
 firebaseSync.addObject( cube, "cube" ); // object and unique id
+firebaseSync.connect();
+...
 ..
 // after changing position.y of cube above
 firebaseSync.saveObject( cube );

--- a/examples/spinning-cube.html
+++ b/examples/spinning-cube.html
@@ -106,7 +106,7 @@ function initScene() {
 		// hide any elements on webpage
 		document.getElementById("info").style.visibility = "hidden";
 
-		var scale = new THREE.Vector3( 2, 2, 2);
+		var scale = new THREE.Vector3( 10, 10, 10);
 		cube.scale.copy( scale );
 		// or cube.scale.set( scale.x, scale.y, scale.z)
 		// note cube.scale = scale won't work, same for cube.position
@@ -175,10 +175,8 @@ function initSync() {
 	var appId = "spinning-cube";
 	firebaseSync = new FirebaseSync( firebaseRootUrl, appId );
 
-	firebaseSync.connect( function() {
-		firebaseSync.addObject( cube, "cube" );
-		onSyncReady();
-	});
+	firebaseSync.addObject( cube, "cube" );
+	firebaseSync.connect( onSyncReady );
 
 }
 


### PR DESCRIPTION
Add apps to call addObject before calling connect, at which point those objects will get synced.
