### PR TITLE
Use the existing `inAltspace` instance variable instead of a global

### DIFF
--- a/src/cursor/CursorEvents.js
+++ b/src/cursor/CursorEvents.js
@@ -27,7 +27,7 @@ CursorEvents = function( params ) {
 
 	this.inAltspace = !!window.Alt;
 
-	if ( inAltspace ) {
+	if ( this.inAltspace ) {
 
 		var dispatcher = this._holoCursorDispatch.bind( this ); 
 


### PR DESCRIPTION
A bit of de-linting as well.
