### PR TITLE
Fix spinning-cube example to work with new renderer

### DIFF
--- a/examples/spinning-cube.html
+++ b/examples/spinning-cube.html
@@ -135,8 +135,7 @@ function initScene() {
 	} else {
 
 		renderer = new THREE.WebGLRenderer();
-		renderer.setClearColor("#AAAAAA")
-;
+		renderer.setClearColor("#AAAAAA");
 		renderer.setSize( window.innerWidth, window.innerHeight );
 		document.body.appendChild( renderer.domElement );
 

--- a/src/cursor/ColorHoverEffect.js
+++ b/src/cursor/ColorHoverEffect.js
@@ -10,125 +10,125 @@ ColorHoverEffect = function ( params ) {
 
 	this.hoverObject;
  
-  var p = params || {};
+	var p = params || {};
 
-  if ( p.color && ! (p.color instanceof THREE.Color )) {
-    console.error("Color should be instance of THREE.Color", p.color);
-    return ; // valid color required
-  }
+	if ( p.color && ! (p.color instanceof THREE.Color )) {
+		console.error("Color should be instance of THREE.Color", p.color);
+		return ; // valid color required
+	}
 
-  this.color = p.color || new THREE.Color(1, 1, 0); // yellow-ish
-  this.tintColor = { r: this.color.r, g: this.color.g, b: this.color.b };
+	this.color = p.color || new THREE.Color(1, 1, 0); // yellow-ish
+	this.tintColor = { r: this.color.r, g: this.color.g, b: this.color.b };
 
-  this.dragObject;
+	this.dragObject;
 
 };
 
 
 ColorHoverEffect.prototype.holocursorenter = function( object ) {
 
-  if ( this.dragObject ) return ; // ignore hover events during drag
+	if ( this.dragObject ) return ; // ignore hover events during drag
 
-  if ( this.hoverObject ) {
-    this.unhoverEffect( this.hoverObject );
-  }
+	if ( this.hoverObject ) {
+		this.unhoverEffect( this.hoverObject );
+	}
 
-  this.hoverEffect( object );
+	this.hoverEffect( object );
 
 };
 
 
 ColorHoverEffect.prototype.holocursorleave = function( object ) {
 
-  if ( this.dragObject ) return ; // ignore hover events during drag
+	if ( this.dragObject ) return ; // ignore hover events during drag
 
-  if ( this.hoverObject === object ) {
-    this.unhoverEffect( object );
-  }
+	if ( this.hoverObject === object ) {
+		this.unhoverEffect( object );
+	}
 
 };
 
 
 ColorHoverEffect.prototype.hoverEffect = function( object ) {
 
-  this.hoverObject = object;
+	this.hoverObject = object;
 
-  // Reddish tint color
-  if ( inAltspace ) {
+	// Reddish tint color
+	if ( inAltspace ) {
 
-    if (! object.userData.origTintColor ) {
-      object.userData.origTintColor = object.userData.tintColor;
-    }
+		if (! object.userData.origTintColor ) {
+			object.userData.origTintColor = object.userData.tintColor;
+		}
 
-    object.userData.tintColor = this.tintColor;
-    object.position.x += 0.001; // hack to force AltRender to redraw scene
+		object.userData.tintColor = this.tintColor;
+		object.position.x += 0.001; // hack to force AltRender to redraw scene
 
-    // workaround since deep-tint which isn't working with new renderer
-    object.traverse( function(child) {
+		// workaround since deep-tint which isn't working with new renderer
+		object.traverse( function(child) {
 
-      child.userData.tintColor = this.tintColor;
+			child.userData.tintColor = this.tintColor;
 
-    }.bind( this ));
+		}.bind( this ));
 
-  } else {
+	} else {
 
-    object.traverse( function(child) { // TODO: Is traverse still needed?
-      if ( child.material && child.material instanceof THREE.MeshPhongMaterial) {
+		object.traverse( function(child) { // TODO: Is traverse still needed?
+			if ( child.material && child.material instanceof THREE.MeshPhongMaterial) {
 
-        if (! child.userData.origAmbientColor ) {
-          child.userData.origAmbientColor = child.material.ambient;
-        }
+				if (! child.userData.origAmbientColor ) {
+					child.userData.origAmbientColor = child.material.ambient;
+				}
 
-        child.material.ambient = this.color;
+				child.material.ambient = this.color;
 
-      }
-    }.bind( this )); 
+			}
+		}.bind( this )); 
 
-  }
+	}
 
 };
 
 
 ColorHoverEffect.prototype.unhoverEffect = function( object ) {
 
-  this.hoverObject = null;
+	this.hoverObject = null;
 
-  if ( inAltspace ) {
+	if ( inAltspace ) {
 
-    object.userData.tintColor = object.userData.origTintColor;
-    object.position.x += 0.001; // hack to force AltRender to redraw scene
+		object.userData.tintColor = object.userData.origTintColor;
+		object.position.x += 0.001; // hack to force AltRender to redraw scene
 
-    // workaround since deep-tint isn't working with new renderer
-    object.traverse( function(child) {
+		// workaround since deep-tint isn't working with new renderer
+		object.traverse( function(child) {
 
-      child.userData.tintColor = object.userData.origTintColor;
+			child.userData.tintColor = object.userData.origTintColor;
 
-    });
+		});
 
-  } else {
+	} else {
 
-    object.traverse( function(child) {
+		object.traverse( function(child) {
 
-      if ( child.material && child.material instanceof THREE.MeshPhongMaterial) {
-        if (child.userData.origAmbientColor) {
-          child.material.ambient = child.userData.origAmbientColor;
-        } else {
-          console.error("Cannot clear hover effect", child);
-        }
-      }
+			if ( child.material && child.material instanceof THREE.MeshPhongMaterial) {
+				if (child.userData.origAmbientColor) {
+					child.material.ambient = child.userData.origAmbientColor;
+				} else {
+					console.error("Cannot clear hover effect", child);
+				}
+			}
 
-    }); 
+		}); 
 
-  }
+	}
 };
 
 
 ColorHoverEffect.prototype.update = function( effectsState ) {
 
-  // Remember if a drag is in progress.
-  this.dragObject = effectsState.dragObject;
+	// Remember if a drag is in progress.
+	this.dragObject = effectsState.dragObject;
 
-  // No need to update the effectsState, so return nothing.
+	// No need to update the effectsState, so return nothing.
 
 };
 

--- a/src/cursor/CursorEvents.js
+++ b/src/cursor/CursorEvents.js
@@ -125,35 +125,35 @@ CursorEvents.prototype.update = function() {
 };
 
 CursorEvents.prototype.addObject = function( object ) {
-  // TODO: Corresponding removeEffect method.
+	// TODO: Corresponding removeEffect method.
 
-  if ( !object ) {
-    console.error("CursorEvents.addObject expected one argument");
-    return ; // sanity check
-  }
+	if ( !object ) {
+		console.error("CursorEvents.addObject expected one argument");
+		return ; // sanity check
+	}
 
-  if ( !this.objectLookup[ object.uuid ] ) {
+	if ( !this.objectLookup[ object.uuid ] ) {
 
-    this.objectLookup[ object.uuid ] = object;
+		this.objectLookup[ object.uuid ] = object;
 
-    if ( this.objectControls ) {
-    	this.objectControls.add( object );
-    }
+		if ( this.objectControls ) {
+			this.objectControls.add( object );
+		}
 
-    if ( this.inAltspace ) {
+		if ( this.inAltspace ) {
 
-	    // workaround for events fired on child mesh instead of top-level object
-	    object.traverse( function( child ) {
+			// workaround for events fired on child mesh instead of top-level object
+			object.traverse( function( child ) {
 
-			if ( child instanceof THREE.Mesh ) {
-				this.childMeshToObject[ child.uuid ] = object;
-			}
+				if ( child instanceof THREE.Mesh ) {
+					this.childMeshToObject[ child.uuid ] = object;
+				}
 
-	    }.bind(this));
+			}.bind(this));
 
-    }
+		}
 
-  }
+	}
 
 };
 
@@ -175,7 +175,7 @@ CursorEvents.prototype._holoCursorDispatch = function( event ) {
 		var targetObject = this.objectLookup[ targetUuid ];
 
 		if ( !targetObject && this.inAltspace ) {
-		    // workaround for events fired on child mesh instead of top-level object
+			// workaround for events fired on child mesh instead of top-level object
 			targetObject = this.childMeshToObject[ targetUuid ];
 		}
 
@@ -232,7 +232,7 @@ CursorEvents.prototype._objectControlsDispatch = function( object, eventDetail )
 		cursorRay: eventDetail.raycaster.ray,
 	};
 
-    this._holoCursorDispatch( mockCursorEvent );
+	this._holoCursorDispatch( mockCursorEvent );
 
 };
 
@@ -265,51 +265,51 @@ CursorEvents.prototype._createEventDetail = function( event ) {
 
 CursorEvents.prototype._dispatchEffects = function( object, event ) {
 
-  // Save most recent event, for effects that track cursorRay (like drag).
-  this.effectsState.lastEvent = event;
+	// Save most recent event, for effects that track cursorRay (like drag).
+	this.effectsState.lastEvent = event;
 
-  // No object (e.g. move event with no defaultTarget) or no effects for object.
-  if ( !object || !this.objectEffects[ object.uuid ] ) return ;
+	// No object (e.g. move event with no defaultTarget) or no effects for object.
+	if ( !object || !this.objectEffects[ object.uuid ] ) return ;
 
-  var effects = this.objectEffects[ object.uuid ];
-  for ( var i=0; i < effects.length; i++) {
+	var effects = this.objectEffects[ object.uuid ];
+	for ( var i=0; i < effects.length; i++) {
 
-    var effect = effects[ i ];
-    var effectCallback = null;
+		var effect = effects[ i ];
+		var effectCallback = null;
 
-    if ( effect[ event.type ]) {
+		if ( effect[ event.type ]) {
 
-      effectCallback = effect[ event.type ].bind( effect );
-      effectCallback( object, event );
-    }
-  }
+			effectCallback = effect[ event.type ].bind( effect );
+			effectCallback( object, event );
+		}
+	}
 
 };
 
 
 CursorEvents.prototype._updateEffects = function() {
 
-  // Call update( this.effectState ) on all effects that define it.
-  // Optional return value is the new effect state, useful for effects
-  // that need to share state between them. Note we are chaining updates,
-  // so an effect that depends on state managed by other events should
-  // be added after them.
+	// Call update( this.effectState ) on all effects that define it.
+	// Optional return value is the new effect state, useful for effects
+	// that need to share state between them. Note we are chaining updates,
+	// so an effect that depends on state managed by other events should
+	// be added after them.
 
-  for (var i=0; i < this.effects.length; i++) {
+	for (var i=0; i < this.effects.length; i++) {
 
-    var effect = this.effects[i];
-    if ( effect.update ) {
+		var effect = this.effects[i];
+		if ( effect.update ) {
 
-      var newEffectsState = effect.update( this.effectsState );
-      if ( newEffectsState ) {
+			var newEffectsState = effect.update( this.effectsState );
+			if ( newEffectsState ) {
 
-        this.effectsState = newEffectsState;
+				this.effectsState = newEffectsState;
 
-      }
+			}
 
-    }
-    
-  }
+		}
+
+	}
 
 };
 

--- a/src/cursor/DragPlaneEffect.js
+++ b/src/cursor/DragPlaneEffect.js
@@ -9,203 +9,203 @@
 DragPlaneEffect = function ( params ) {
 
 	this.hoverObject;
-  this.dragObject;
-  this.dragObjectWidth;
+	this.dragObject;
+	this.dragObjectWidth;
 
 	this.dragOffset = new THREE.Vector3();
 
-  // Needed to interect dragPlane and compute new position of dragObject.
-  this.raycaster;
+	// Needed to interect dragPlane and compute new position of dragObject.
+	this.raycaster;
 
-  var p = params || {};
+	var p = params || {};
 
-  this.TRACE = p.TRACE || null;
+	this.TRACE = p.TRACE || null;
 
-  // Save object as drag position changes.
-  this.firebaseSync = p.firebaseSync || null;
+	// Save object as drag position changes.
+	this.firebaseSync = p.firebaseSync || null;
 
-  // Disable orbit controls during a drag (non-Altspace only). 
-  this.orbitControls = p.orbitControls || null;
+	// Disable orbit controls during a drag (non-Altspace only). 
+	this.orbitControls = p.orbitControls || null;
 
-  this.dragPlane = p.dragPlane || null;
+	this.dragPlane = p.dragPlane || null;
 
-  if ( !this.dragPlane ) {
-    // Default drag plane, for demo only! Normally it should be passed in,
-    // with location and width/depth matching drag area of your scene.
-    // Do not add dragPlane to the scene, or raycasting doesn't work properly.
-    this.dragPlane = new THREE.Mesh( 
-      new THREE.BoxGeometry( window.innerWidth, 0.25, window.innerDepth || 2000 ),
-      new THREE.MeshBasicMaterial( { transparent: true, opacity: 0.25 })
-    );
+	if ( !this.dragPlane ) {
+		// Default drag plane, for demo only! Normally it should be passed in,
+		// with location and width/depth matching drag area of your scene.
+		// Do not add dragPlane to the scene, or raycasting doesn't work properly.
+		this.dragPlane = new THREE.Mesh( 
+			new THREE.BoxGeometry( window.innerWidth, 0.25, window.innerDepth || 2000 ),
+			new THREE.MeshBasicMaterial( { transparent: true, opacity: 0.25 })
+		);
 
-  }
+	}
 
-  // Mark the intersection point when an object is dragged and on hoverOver.
-  // Intended as a debugging aide. Mesh with SphereGeometry works well.
-  this.dragPointMarker = p.dragPointMarker || null;
+	// Mark the intersection point when an object is dragged and on hoverOver.
+	// Intended as a debugging aide. Mesh with SphereGeometry works well.
+	this.dragPointMarker = p.dragPointMarker || null;
 
 };
 
 DragPlaneEffect.prototype.holocursordown = function( object, event ) {
 
-  this.dragStart( object, event );
+	this.dragStart( object, event );
 
 }
 
 DragPlaneEffect.prototype.holocursorup = function( object, event ) {
 
-  this.dragEnd( object, event );
+	this.dragEnd( object, event );
 
-  // To use click-release to start drag, move, then click-release to end drag,
-  // ignore holocursordown and toggle between start/end drag here as follows:
-  // this.dragObject ? this.dragEnd( object, event ) : this.dragStart( object, event );
-  // We could add this as option set in constructor params if desired.
+	// To use click-release to start drag, move, then click-release to end drag,
+	// ignore holocursordown and toggle between start/end drag here as follows:
+	// this.dragObject ? this.dragEnd( object, event ) : this.dragStart( object, event );
+	// We could add this as option set in constructor params if desired.
 
 }
 
 
 DragPlaneEffect.prototype.dragStart = function( object, event ) {
 
-  if ( this.TRACE ) console.log("Starting drag", object);
+	if ( this.TRACE ) console.log("Starting drag", object);
 
-  this.dragObject = object;
+	this.dragObject = object;
 
-  var boudingBox = new THREE.Box3().setFromObject( this.dragObject );
-  this.dragObjectWidth = Math.abs( boudingBox.max.x - boudingBox.min.x );
+	var boudingBox = new THREE.Box3().setFromObject( this.dragObject );
+	this.dragObjectWidth = Math.abs( boudingBox.max.x - boudingBox.min.x );
 
-  if ( this.TRACE ) console.log( "dragObject width: " + this.dragObjectWidth );
+	if ( this.TRACE ) console.log( "dragObject width: " + this.dragObjectWidth );
 
-  var intersects = this.raycaster.intersectObject( object, true );
-  if ( intersects.length === 0) {
-    console.error("dragStart but no intersected object");
-    return ; // something went wrong
-  }
-  var intersectionPoint = intersects[0].point;
-  if ( this.TRACE ) console.log( "Intersection point:", intersectionPoint );
+	var intersects = this.raycaster.intersectObject( object, true );
+	if ( intersects.length === 0) {
+		console.error("dragStart but no intersected object");
+		return ; // something went wrong
+	}
+	var intersectionPoint = intersects[0].point;
+	if ( this.TRACE ) console.log( "Intersection point:", intersectionPoint );
 
-  if ( this.dragObject ) {
+	if ( this.dragObject ) {
 
-    if ( this.orbitControls ) {
-      this.orbitControls.enabled = false;
-    }
+		if ( this.orbitControls ) {
+			this.orbitControls.enabled = false;
+		}
 
-    // Raise/lower the drag plane to match the drag start point.
-    this.dragPlane.position.y = intersectionPoint.y;
+		// Raise/lower the drag plane to match the drag start point.
+		this.dragPlane.position.y = intersectionPoint.y;
 
-    // Force update, otherwise old position of dragPlane is used when raycaster
-    // computes drag point later, and objects appear to "jump" when selected.
-    this.dragPlane.updateMatrixWorld();
-    if ( this.TRACE ) console.log( "Moving dragPlane.position.y to " + intersectionPoint.y );
+		// Force update, otherwise old position of dragPlane is used when raycaster
+		// computes drag point later, and objects appear to "jump" when selected.
+		this.dragPlane.updateMatrixWorld();
+		if ( this.TRACE ) console.log( "Moving dragPlane.position.y to " + intersectionPoint.y );
 
-    // Remember difference between center of object and drag point.
-    var objectCenterPoint = this.dragObject.position.clone();
-    objectCenterPoint.y = this.dragPlane.position.y;
-    this.dragOffset.copy( intersectionPoint ).sub( objectCenterPoint );
+		// Remember difference between center of object and drag point.
+		var objectCenterPoint = this.dragObject.position.clone();
+		objectCenterPoint.y = this.dragPlane.position.y;
+		this.dragOffset.copy( intersectionPoint ).sub( objectCenterPoint );
 
-  } else {
+	} else {
 
-    console.error("dragStart called, but object not selected");
+		console.error("dragStart called, but object not selected");
 
-  }
+	}
 
 };
 
 
 DragPlaneEffect.prototype.dragEnd = function( object, event ) {
 
-    if ( this.TRACE ) console.log("Ending drag", object);
+		if ( this.TRACE ) console.log("Ending drag", object);
 
-    if ( this.orbitControls ) {
-      this.orbitControls.enabled = true;
-    }
+		if ( this.orbitControls ) {
+			this.orbitControls.enabled = true;
+		}
 
-    this.dragObject = null;
+		this.dragObject = null;
 
-    // Return dragPlane to ground-level. Not strictly needed since we'll reset
-    // on new drag, but looks better if the dragPlane is visible, e.g. for debugging.
-    this.dragPlane.position.y = 0;
+		// Return dragPlane to ground-level. Not strictly needed since we'll reset
+		// on new drag, but looks better if the dragPlane is visible, e.g. for debugging.
+		this.dragPlane.position.y = 0;
 };
 
 
 DragPlaneEffect.prototype.update = function( effectsState ) {
-  // based on http://threejs.org/examples/#webgl_interactive_draggablecubes
-  // but changed to constrain dragging to x-z ground plane, instead of x-y vertical plane.
+	// based on http://threejs.org/examples/#webgl_interactive_draggablecubes
+	// but changed to constrain dragging to x-z ground plane, instead of x-y vertical plane.
 
-  effectsState.dragObject = this.dragObject;
+	effectsState.dragObject = this.dragObject;
 
-  this._setRaycaster( effectsState.lastEvent );
+	this._setRaycaster( effectsState.lastEvent );
 
-  if (!this.dragObject) return effectsState ;  // No drag, we're done.
+	if (!this.dragObject) return effectsState ;  // No drag, we're done.
 
-  var intersects = this.raycaster.intersectObject( this.dragPlane );
+	var intersects = this.raycaster.intersectObject( this.dragPlane );
 
-  if (intersects.length === 0) {
-    if ( this.TRACE ) console.log( "Ray no longer intersection dragplane", this.raycaster, this.dragPlane);
-    this.dragEnd();
-    return effectsState ;
-  }
+	if (intersects.length === 0) {
+		if ( this.TRACE ) console.log( "Ray no longer intersection dragplane", this.raycaster, this.dragPlane);
+		this.dragEnd();
+		return effectsState ;
+	}
 
-  var dragPoint = intersects[0].point.clone();
+	var dragPoint = intersects[0].point.clone();
 
-  if ( this.dragPointMarker ) {
-    this.dragPointMarker.position.x = dragPoint.x;
-    this.dragPointMarker.position.y = dragPoint.y;
-    this.dragPointMarker.position.z = dragPoint.z;
-  }
+	if ( this.dragPointMarker ) {
+		this.dragPointMarker.position.x = dragPoint.x;
+		this.dragPointMarker.position.y = dragPoint.y;
+		this.dragPointMarker.position.z = dragPoint.z;
+	}
 
-  // Update object position to where raycaster intersects dragPlane (minus offset).
-  var newPosition = new THREE.Vector3();
-  newPosition.copy( dragPoint ).sub( this.dragOffset );
+	// Update object position to where raycaster intersects dragPlane (minus offset).
+	var newPosition = new THREE.Vector3();
+	newPosition.copy( dragPoint ).sub( this.dragOffset );
 
-  // But maintain the original y position of the object.
-  newPosition.y = this.dragObject.position.y;
+	// But maintain the original y position of the object.
+	newPosition.y = this.dragObject.position.y;
 
-  // Constrain new position to the width and depth of the dragPlane.
-  // Prevents object from getting moved outside the bounding volume in Altspace.
-  // Account for object width, otherwise objects end up halfway off the dragPlane.
-  var params = this.dragPlane.geometry.parameters;
-  var objectWidth = this.dragObjectWidth;
+	// Constrain new position to the width and depth of the dragPlane.
+	// Prevents object from getting moved outside the bounding volume in Altspace.
+	// Account for object width, otherwise objects end up halfway off the dragPlane.
+	var params = this.dragPlane.geometry.parameters;
+	var objectWidth = this.dragObjectWidth;
 
-  if (dragPoint.x - objectWidth/2 < this.dragPlane.position.x - params.width/2) {
-    newPosition.x = this.dragPlane.position.x - params.width/2 + objectWidth/2;
-  }
-  if (dragPoint.x + objectWidth/2 > this.dragPlane.position.x + params.width/2) {
-    newPosition.x = this.dragPlane.position.x + params.width/2 - objectWidth/2;
-  }
-  if (dragPoint.z - objectWidth/2 < this.dragPlane.position.z - params.depth/2) {
-    newPosition.z = this.dragPlane.position.z - params.depth/2 + objectWidth/2;
-  }
-  if (dragPoint.z + objectWidth/2 > this.dragPlane.position.z + params.depth/2) {
-    newPosition.z = this.dragPlane.position.z + params.depth/2 - objectWidth/2;
-  }
+	if (dragPoint.x - objectWidth/2 < this.dragPlane.position.x - params.width/2) {
+		newPosition.x = this.dragPlane.position.x - params.width/2 + objectWidth/2;
+	}
+	if (dragPoint.x + objectWidth/2 > this.dragPlane.position.x + params.width/2) {
+		newPosition.x = this.dragPlane.position.x + params.width/2 - objectWidth/2;
+	}
+	if (dragPoint.z - objectWidth/2 < this.dragPlane.position.z - params.depth/2) {
+		newPosition.z = this.dragPlane.position.z - params.depth/2 + objectWidth/2;
+	}
+	if (dragPoint.z + objectWidth/2 > this.dragPlane.position.z + params.depth/2) {
+		newPosition.z = this.dragPlane.position.z + params.depth/2 - objectWidth/2;
+	}
 
-  this.dragObject.position.copy( newPosition );
+	this.dragObject.position.copy( newPosition );
 
-  // Save our new position to the cloud, will update other players.
-  if ( this.firebaseSync ) {
-    this.firebaseSync.saveObject(this.dragObject);
-  }
+	// Save our new position to the cloud, will update other players.
+	if ( this.firebaseSync ) {
+		this.firebaseSync.saveObject(this.dragObject);
+	}
 
-  return effectsState;
+	return effectsState;
 };
 
 
 DragPlaneEffect.prototype._setRaycaster = function( lastEvent ) {
 
-  if ( !lastEvent ) return ; // No cursor events yet.
+	if ( !lastEvent ) return ; // No cursor events yet.
 
-  if ( !this.raycaster ) {
-    var params = this.dragPlane.geometry.parameters;
-    this.raycaster = new THREE.Raycaster();
+	if ( !this.raycaster ) {
+		var params = this.dragPlane.geometry.parameters;
+		this.raycaster = new THREE.Raycaster();
 
-    // Raycaster usually set from Three.js camera, but here assume near=1 and
-    // make "far" 20% bigger than dragplane (if smaller, raycast won't work).
-    this.raycaster.near = 1;
-    this.raycaster.far = Math.max(params.width, params.depth) * 1.2;
-  }
+		// Raycaster usually set from Three.js camera, but here assume near=1 and
+		// make "far" 20% bigger than dragplane (if smaller, raycast won't work).
+		this.raycaster.near = 1;
+		this.raycaster.far = Math.max(params.width, params.depth) * 1.2;
+	}
 
-  var cursorRay = lastEvent.detail.cursorRay;
-  this.raycaster.set( cursorRay.origin, cursorRay.direction );
+	var cursorRay = lastEvent.detail.cursorRay;
+	this.raycaster.set( cursorRay.origin, cursorRay.direction );
 
 };
 


### PR DESCRIPTION
Now spinning-cube example upgraded to renderer 0.2.0, and upgraded CursorEvents to handle events being fired on child meshes (so we're doing the "bubling" in the SDK).  This version of CursorEvents still works with old renderer; tested with chess and solar system apps. 
