### PR TITLE
Render to WebGL if window too small

### DIFF
--- a/examples/chess.html
+++ b/examples/chess.html
@@ -2,19 +2,19 @@
 <html lang='en'>
 <head>
 <title>Chess</title>
-<script src='http://sdk.altvr.com/libs/three.js/r71/build/three.min.js'></script>
-<script src='http://sdk.altvr.com/libs/three.js/r71/examples/js/loaders/OBJMTLLoader.js'></script>
-<script src='http://sdk.altvr.com/libs/three.js/r71/examples/js/loaders/MTLLoader.js'></script>
-<script src='http://sdk.altvr.com/libs/three.js/r71/examples/js/controls/OrbitControls.js'></script>
-<script src='http://sdk.altvr.com/libs/altspace.js/latest/altspace.min.js'></script>
-<script src='http://cdn.firebase.com/js/client/2.2.9/firebase.js'></script>
+<script src="http://sdk.altvr.com/libs/three.js/r71/build/three.min.js"></script>
+<script src="http://sdk.altvr.com/libs/three.js/r71/examples/js/loaders/OBJMTLLoader.js"></script>
+<script src="http://sdk.altvr.com/libs/three.js/r71/examples/js/loaders/MTLLoader.js"></script>
+<script src="http://sdk.altvr.com/libs/three.js/r71/examples/js/controls/OrbitControls.js"></script>
+<script src="http://sdk.altvr.com/libs/altspace.js/latest/altspace.min.js"></script>
+<script src="http://cdn.firebase.com/js/client/2.2.9/firebase.js"></script>
 
-<script src='http://sdk.altvr.com/utilities/0.3.2/CursorEffects.js'></script>
-<script src='http://sdk.altvr.com/utilities/0.3.2/ColorHoverEffect.js'></script>
-<script src='http://sdk.altvr.com/utilities/0.3.2/DragPlaneEffect.js'></script>
-<script src='http://sdk.altvr.com/utilities/0.3.2/ThreeBase.js'></script>
-<script src='http://sdk.altvr.com/utilities/0.3.2/MultiLoader.js'></script>
-<script src='http://sdk.altvr.com/utilities/0.3.2/shims/CursorEvents.js'></script>
+<script src="http://sdk.altvr.com/utilities/0.4.0/CursorEffects.js"></script>
+<script src="http://sdk.altvr.com/utilities/0.4.0/ColorHoverEffect.js"></script>
+<script src="http://sdk.altvr.com/utilities/0.4.0/DragPlaneEffect.js"></script>
+<script src="http://sdk.altvr.com/utilities/0.4.0/ThreeBase.js"></script>
+<script src="http://sdk.altvr.com/utilities/0.4.0/MultiLoader.js"></script>
+<script src="http://sdk.altvr.com/utilities/0.4.0/shims/CursorEvents.js"></script>
 
 </head>
 <body>
@@ -22,19 +22,20 @@
 
 ChessApp = (function(){
 	//Chess Board with draggable pieces and multiplayer sychronization.
+	var ascp = altspace.utilities.codePen;
+	var inAltspace = !!(window.altspace && window.altspace.inClient);
+	var inCodePen = !!location.href.match('codepen.io/');
+	var useAltRenderer = inAltspace && (!inCodePen || window.innerHeight >= 750);
+
 	var scene, camera, renderer;
 	var threeBase;
-	var inAltspace = window.altspace && window.altspace.inClient;
 
 	function main(){
 		//Entry point into the app, kicks off the rendering loop.
+		ascp.setName('Chess'); 
 		initThreeBase();
 		initScene();
-		if (inAltspace){
-			var enclosureHeight = 1000;//TODO: Get height of enclosure dynamically.
-			scene.position.y = enclosureHeight / -2 ;//Lower board onto floor/table.
-		}
-		ChessBoard.init(scene, threeBase, function(){//onComplete//XXX
+		ChessBoard.init(scene, threeBase, function(){//onComplete
 			console.log('Chess Board initialized');
 			animate();
 		});
@@ -42,9 +43,6 @@ ChessApp = (function(){
 
 	function initThreeBase(){
 		//ThreeBase synchronizes the game objects across multiple clients.
-		var ascp = altspace.utilities.codePen;
-		ascp.setName('Chess'); 
-		var inCodePen = !!ascp.getPenId().match(/[0-9][a-f].*/);
 		var syncParams = inCodePen ? {
 			instanceId: ascp.getPenId(),
 			authorId: ascp.getAuthorId()
@@ -57,8 +55,11 @@ ChessApp = (function(){
 	function initScene(){
 		//This app works both in Altspace and in a traditional browser.
 		scene = new THREE.Scene();
-		if (inAltspace){
-		    renderer = altspace.getThreeJSRenderer();
+		if (useAltRenderer){
+	    renderer = altspace.getThreeJSRenderer();
+			//TODO: Remove hardcoded enclosure height once promises work in iframes.
+			var enclosureHeight = 1024;
+			scene.position.y = enclosureHeight / -2 ;//Lower board onto botton of enclosure.
 		} else {
 			renderer = new THREE.WebGLRenderer({antialias: true});
 			camera = new THREE.PerspectiveCamera();

--- a/examples/spinning-cube.html
+++ b/examples/spinning-cube.html
@@ -6,7 +6,7 @@
 <script src="http://sdk.altvr.com/libs/three.js/r71/build/three.min.js"></script>
 <script src="http://sdk.altvr.com/libs/three.js/r71/examples/js/loaders/MTLLoader.js"></script>
 <script src="http://sdk.altvr.com/libs/altspace.js/latest/altspace.min.js"></script>
-<script src="http://sdk.altvr.com/utilities/0.3.2/shims/CursorEvents.js"></script>
+<script src="http://sdk.altvr.com/utilities/0.4.0/shims/CursorEvents.js"></script>
 </head>
 <body>
 </body>
@@ -14,7 +14,7 @@
 
 var ascp = altspace.utilities.codePen;
 ascp.setName('Hello Cube'); 
-var inCodePen = !!ascp.getPenId().match(/[0-9][a-f].*/);
+var inCodePen = !!location.href.match('codepen.io/');
 var inAltspace = window.altspace && window.altspace.inClient;
 
 // Setup

--- a/utilities/DragPlaneEffect.js
+++ b/utilities/DragPlaneEffect.js
@@ -8,7 +8,6 @@ window.altspace.utilities.DragPlaneEffect = function(){
   var raycaster = new THREE.Raycaster();
   var rayOrigin = new THREE.Vector3();
   var rayDirection = new THREE.Vector3();
-  var inAltspace = window.altspace && window.altspace.inClient;
 
   // for debugging
   var orbitControls;
@@ -68,7 +67,7 @@ window.altspace.utilities.DragPlaneEffect = function(){
     var boudingBox = new THREE.Box3().setFromObject(dragObject);
     dragObjectWidth = Math.abs(boudingBox.max.x - boudingBox.min.x);
     var intersectionPoint = event.point.clone();
-    if (inAltspace){
+    if (!event.isShimEvent){
       //TODO: Investigate if bug in Altspace event or our mistake.
       intersectionPoint.z *= -1;//invert z cordinate
     }

--- a/utilities/MultiLoader.js
+++ b/utilities/MultiLoader.js
@@ -65,7 +65,8 @@ altspace.utilities.MultiLoader = (function(){
             onComplete();
           }
         }, onProgress, function(){//onError 
-          req.error = 'Error loading file: '+xhr.target.responseURL;
+          var url = xhr.target.responseURL || '';
+          req.error = 'Error loading file '+url;
         });
       };
       loadModel(req, i);
@@ -73,7 +74,8 @@ altspace.utilities.MultiLoader = (function(){
   }
 
   function onProgress(xhr){
-    if (xhr.lengthComputable) {
+    if (xhr.lengthComputable && xhr.target.responseURL) {
+      //Skip progress log if no xhr url, meaning it's a local file.
       var percentComplete = xhr.loaded / xhr.total * 100;
       var filename = xhr.target.responseURL.split('/').pop();
       if (TRACE) console.log('...'+filename+' '+Math.round(percentComplete,2)+'% downloaded');

--- a/utilities/shims/CursorEvents.js
+++ b/utilities/shims/CursorEvents.js
@@ -117,6 +117,7 @@ window.altspace.utilities.CursorEvents = (function(){
         direction: direction,
       },
       type: eventName,
+      isShimEvent: true,//for workarounds related to quirks in Altspace events
     }
     return mockCursorEvent;
   }


### PR DESCRIPTION
Fixes issue with chess displaying in the Codepen Editing preview window.
Now if we're in Altspace and in Codepen, only use AltRenderer if window
height is >= 750.
