### PR TITLE
Scale cube to be 1 meter in altspace

### DIFF
--- a/examples/spinning-cube.html
+++ b/examples/spinning-cube.html
@@ -11,10 +11,8 @@
 </body>
 <script>
 
-var CUBE_SCALE = 150;
-//can change above value in live-coding, 10-500 works well
-
 var sim = altspace.utilities.Simulation();
+sim.camera.position.z = 5;
 var config = { authorId: 'AltspaceVR', appId: 'SpinningCube' };
 var sceneSync;
 altspace.utilities.sync.connect(config).then(function(connection) {
@@ -36,7 +34,6 @@ function createCube() {
 	var geometry = new THREE.BoxGeometry(1, 1, 1);
 	var material = new THREE.MeshBasicMaterial({color:'#ffffff', map: texture});
 	var cube = new THREE.Mesh(geometry, material);
-	cube.scale.multiplyScalar(CUBE_SCALE);
 	cube.addBehaviors(
 		altspace.utilities.behaviors.Object3DSync(),
 		altspace.utilities.behaviors.Spin({speed: 0.0005}),
@@ -75,6 +72,14 @@ function ChangeColor() {//define a custom behavior
 			var color = Please.make_color()[0];//random color
 			colorRef.set(color);
 		});
+
+		if (altspace && altspace.inClient) {
+			altspace.getEnclosure().then(function(e) {
+				// scale cube so it's 1 meter in Altspace
+				object3d.scale.multiplyScalar(e.pixelsPerMeter);
+			});
+		}
+
 	}
 
 	function update(deltaTime) {


### PR DESCRIPTION
Use enclosure pixelsPerMeter to make cube 1 meter in world-space.
Outside altspace, set camera 5 units back, instead of Simulation default
500, otherwise cube looks tiny since it's now only 1 unit in
length/height/width.